### PR TITLE
opack: better handling of args

### DIFF
--- a/js/opack.js
+++ b/js/opack.js
@@ -1247,8 +1247,10 @@ function __opack_script(args, isDaemon, isJob) {
 	var windows   = (os.match(/Windows/)) ? 1 : 0;
 	classPath = (new java.io.File(classPath)).getAbsoluteFile();
 	var javaargs = "";
-	for(var i in __args) {
-		if (__args[i].match(/^args=/i)) javaargs = __args[i].replaceAll("^args=", "");
+	var params = splitBySeparator(__expr, " ");
+	for(var i in params) {
+		var param = splitBySeparator(params[i], "=");
+		if (param.length == 2 && param[0] == "args") javaargs = param[1];
 	}
 
 	function generateUnixScript(options) {


### PR DESCRIPTION
better handling of "opack script args=".
The idea is to be able to generate scripts by executing "opack script xpto args=-Xms64m\\ -Xmx256m".