### PR TITLE
issue 95: converting oracle timestamp with time zone

### DIFF
--- a/src/openaf/core/DB.java
+++ b/src/openaf/core/DB.java
@@ -218,7 +218,8 @@ public class DB {
 								}
 
 								if((rs.getMetaData().getColumnType(i) == java.sql.Types.TIMESTAMP) || 
-								(rs.getMetaData().getColumnType(i) == java.sql.Types.TIMESTAMP_WITH_TIMEZONE)) {
+								   (rs.getMetaData().getColumnType(i) == java.sql.Types.TIMESTAMP_WITH_TIMEZONE) ||
+								   (rs.getMetaData().getColumnTypeName(i).equals("TIMESTAMP WITH TIME ZONE"))) {
 									if (rs.getTimestamp(i) != null)
 										record.put(rs.getMetaData().getColumnName(i), AFCmdBase.jse.newObject((Scriptable) AFCmdBase.jse.getGlobalscope(), "Date", new Object[] { rs.getTimestamp(i).getTime() }));
 									else
@@ -379,7 +380,8 @@ public class DB {
 								}
 
 								if((rs.getMetaData().getColumnType(i) == java.sql.Types.TIMESTAMP) || 
-								(rs.getMetaData().getColumnType(i) == java.sql.Types.TIMESTAMP_WITH_TIMEZONE)) {
+								   (rs.getMetaData().getColumnType(i) == java.sql.Types.TIMESTAMP_WITH_TIMEZONE) ||
+								   (rs.getMetaData().getColumnTypeName(i).equals("TIMESTAMP WITH TIME ZONE"))) {
 									record.put(rs.getMetaData().getColumnName(i), AFCmdBase.jse.newObject((Scriptable) AFCmdBase.jse.getGlobalscope(), "Date", new Object[] { rs.getTimestamp(i).getTime() }));
 									continue;
 								}


### PR DESCRIPTION
converting oracle timestamp with time zone (when convertDates = true)

Oracle returns column type -101 so checking also the type name for "TIMESTAMP WITH TIME ZONE".
Easy way to test: 
````javascript
> var db = [some oracle db]
> db.convertDates(true)
> sql db select current_timestamp,current_date,sysdate from dual
````