### PR TITLE
Changes to solve issue #158 and improve encoding support

### DIFF
--- a/js/owrap.obj.js
+++ b/js/owrap.obj.js
@@ -1894,7 +1894,7 @@ OpenWrap.obj.prototype.rest = {
 				   merge({"Content-Type":"application/json"} , aRequestMap);
 
 		try {
-			return h.exec(aURL + ow.obj.rest.writeIndexes(aIdx), "POST", (urlEncode) ? ow.obj.rest.writeQuery(aDataRow) : stringify(aDataRow, undefined, ''), rmap, retBytes, _t, retBytes);
+			return h.exec(aURL + ow.obj.rest.writeIndexes(aIdx), "POST", (urlEncode) ? ow.obj.rest.writeQuery(aDataRow) : af.toEncoding(stringify(aDataRow, void 0, ''), "cp1252", "UTF-8"), rmap, retBytes, _t, retBytes);
 		} catch(e) {
 			e.message = "Exception " + e.message + "; error = " + String(h.getErrorResponse(true));
 			throw e;
@@ -1946,10 +1946,10 @@ OpenWrap.obj.prototype.rest = {
 		
 		var rmap = (urlEncode) ?
 		           merge({"Content-Type":"application/x-www-form-urlencoded"} , aRequestMap) :
-				   merge({"Content-Type":"application/json"} , aRequestMap);
+				   merge({"Content-Type":"application/json; charset=utf-8"} , aRequestMap);
 		
 		try {
-			return h.exec(aURL + ow.obj.rest.writeIndexes(aIdx), "PUT", (urlEncode) ? ow.obj.rest.writeQuery(aDataRow) : stringify(aDataRow, undefined, ''), rmap, retBytes, _t, retBytes);
+			return h.exec(aURL + ow.obj.rest.writeIndexes(aIdx), "PUT", (urlEncode) ? ow.obj.rest.writeQuery(aDataRow) : af.toEncoding(stringify(aDataRow, void 0, ''), "cp1252", "UTF-8"), rmap, retBytes, _t, retBytes);
 		} catch(e) {
 			e.message = "Exception " + e.message + "; error = " + String(h.getErrorResponse(true));
 			throw e;
@@ -2001,10 +2001,10 @@ OpenWrap.obj.prototype.rest = {
 		
 		var rmap = (urlEncode) ?
 		           merge({"Content-Type":"application/x-www-form-urlencoded"} , aRequestMap) :
-				   merge({"Content-Type":"application/json"} , aRequestMap);
+				   merge({"Content-Type":"application/json; charset=utf-8"} , aRequestMap);
 		
 		try {
-			return h.exec(aURL + ow.obj.rest.writeIndexes(aIdx), "PATCH", (urlEncode) ? ow.obj.rest.writeQuery(aDataRow) : stringify(aDataRow, undefined, ''), rmap, retBytes, _t, retBytes);
+			return h.exec(aURL + ow.obj.rest.writeIndexes(aIdx), "PATCH", (urlEncode) ? ow.obj.rest.writeQuery(aDataRow) : af.toEncoding(stringify(aDataRow, void 0, ''), "cp1252", "UTF-8"), rmap, retBytes, _t, retBytes);
 		} catch(e) {
 			e.message = "Exception " + e.message + "; error = " + String(h.getErrorResponse(true));
 			throw e;


### PR DESCRIPTION
- af functions to/from String wherever a byte conversion is used now support to specify the encoding
- new af.toEncoding function
- ow.obj.rest now uses af.toEncoding to ensure json contents are sent in UTF-8 + content-type header added note for utf-8
- openaf-console: several improvements for better handling of encodings and code pages in Windows