### PR TITLE
openmetrics label max size

### DIFF
--- a/js/openaf.js
+++ b/js/openaf.js
@@ -6627,11 +6627,12 @@ const loadJSYAML = function() {
 loadCompiledLib("openafsigil_js");
 
 var __flags = _$(__flags).isMap().default({
-	OJOB_SEQUENTIAL  : true,
-	OJOB_HELPSIMPLEUI: false,
-	OAF_CLOSED       : false,
-	VISIBLELENGTH    : false,
-	MD_NOMAXWIDTH    : true
+	OJOB_SEQUENTIAL            : true,
+	OJOB_HELPSIMPLEUI          : false,
+	OAF_CLOSED                 : false,
+	VISIBLELENGTH              : false,
+	MD_NOMAXWIDTH              : true,
+	OPENMETRICS_LABEL_VALUE_MAX: true   // If false openmetrics label value length won't be restricted
 })
 
 /**

--- a/js/openaf.js
+++ b/js/openaf.js
@@ -6632,7 +6632,7 @@ var __flags = _$(__flags).isMap().default({
 	OAF_CLOSED                 : false,
 	VISIBLELENGTH              : false,
 	MD_NOMAXWIDTH              : true,
-	OPENMETRICS_LABEL_VALUE_MAX: true   // If false openmetrics label value length won't be restricted
+	OPENMETRICS_LABEL_MAX      : true   // If false openmetrics label name & value length won't be restricted
 })
 
 /**

--- a/js/owrap.metrics.js
+++ b/js/owrap.metrics.js
@@ -445,8 +445,11 @@ OpenWrap.metrics.prototype.fromObj2OpenMetrics = function(aObj, aPrefix, aTimest
             // build labels
             lbs = _$(lbs).default([])
             keys.forEach(key => {
-                if (!isNumber(obj[key]) && !isBoolean(obj[key]) && isDef(obj[key]) && !isArray(obj[key]) && !isMap(obj[key]) ) 
-                    lbs.push(key + "=\"" + String(obj[key]).replace(/\n/g, "\\\n").replace(/\"/g, "\\\\") + "\"")
+                if (!isNumber(obj[key]) && !isBoolean(obj[key]) && isDef(obj[key]) && !isArray(obj[key]) && !isMap(obj[key]) ) {
+                    var value = String(obj[key])
+                    if (__flags.OPENMETRICS_LABEL_VALUE_MAX && value.length > 128) value = value.substring(0, 128)
+                    lbs.push(key + "=\"" + value.replace(/\n/g, "\\\\n").replace(/\\/g, "\\\\").replace(/\"/g, "\\\"") + "\"")
+                }
             })
             var lprefix = (lbs.length > 0 ? "{" + lbs.join(",") + "}" : "")
 

--- a/js/owrap.metrics.js
+++ b/js/owrap.metrics.js
@@ -413,13 +413,14 @@ OpenWrap.metrics.prototype.fromOpenMetrics2Array = function(lines) {
  * <odoc>
  * <key>ow.metrics.fromObj2OpenMetrics(aObj, aPrefix, aTimestamp, aHelpMap) : String</key>
  * Given aObj will return a string of open metric (prometheus) metric strings. Optionally you can provide a prefix (defaults to "metric") 
- * and/or aTimestamp (that will be used for all aObj values).
+ * and/or aTimestamp (that will be used for all aObj values). Note: prefixes should not start with a digit.
  * </odoc>
  */
 OpenWrap.metrics.prototype.fromObj2OpenMetrics = function(aObj, aPrefix, aTimestamp, aHelpMap) {
     var handled = false
     aPrefix = _$(aPrefix, "prefix").isString().default("metric")
     aPrefix = aPrefix.replace(/[^a-zA-Z0-9]/g, "_")
+    if (/\d.+/.test(aPrefix)) aPrefix = "_" + aPrefix
 
     // https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md
 
@@ -446,9 +447,21 @@ OpenWrap.metrics.prototype.fromObj2OpenMetrics = function(aObj, aPrefix, aTimest
             lbs = _$(lbs).default([])
             keys.forEach(key => {
                 if (!isNumber(obj[key]) && !isBoolean(obj[key]) && isDef(obj[key]) && !isArray(obj[key]) && !isMap(obj[key]) ) {
-                    var value = String(obj[key])
-                    if (__flags.OPENMETRICS_LABEL_VALUE_MAX && value.length > 128) value = value.substring(0, 128)
-                    lbs.push(key + "=\"" + value.replace(/\n/g, "\\\\n").replace(/\\/g, "\\\\").replace(/\"/g, "\\\"") + "\"")
+                    var _key   = String(key)
+                    var _value = String(obj[key])
+                    // Handling limits
+                    if (__flags.OPENMETRICS_LABEL_MAX) {
+                        if (_key.length > 128)   _key = _key.substring(0, 128)
+                        if (_value.length > 128) _value = _value.substring(0, 128)
+                    }
+                    
+                    // Escaping
+                    if (/\d.+/.test(_key)) _key = "_" + _key
+                    _key = _key.replace(/[^a-zA-Z0-9]/g, "_")
+                    _value = _value.replace(/\n/g, "\\\\n").replace(/\\/g, "\\\\").replace(/\"/g, "\\\"")
+                    
+                    // Adding
+                    lbs.push(_key + "=\"" + _value + "\"")
                 }
             })
             var lprefix = (lbs.length > 0 ? "{" + lbs.join(",") + "}" : "")


### PR DESCRIPTION
On the ow.metrics.fromObj2OpenMetrics conversion the source map might have values with "extensive" string lengths that might lead to memory and performance issues. It also defeats the propose of the OpenMetrics labels. Therefore a limit to the max size of a label name & value should be managed. The limit was establish to be on 128 characters. Nevertheless the limitation can be overridden by using the general __flags.OPENMETRICS_LABEL_MAX = false.

Additional improvements were also made to the label key and values escaping.