### PR TITLE
ow.format.grid: correct mx and my

### DIFF
--- a/js/owrap.format.js
+++ b/js/owrap.format.js
@@ -596,10 +596,10 @@ OpenWrap.format.prototype.string = {
 					var p = "", cs = Math.floor((aY / line.length) * xspan);
 			
 					switch(col.type) {
-					case "map"  : p = printMap(col.obj, cs, "utf", true); break; 
-					case "table": p = printTable(col.obj, cs, __, true, "utf"); break;
-					case "func" : p = String(newFn("mx", "my", col.obj)((aX * yspan), cs)).split(/\r?\n/).map(r => r.substring(0, cs)).join("\n"); break;
-					default: p = String(col.obj).split(/\r?\n/).map(r => r.substring(0, cs)).join("\n");
+					case "map"  : p = printMap(col.obj, cs-1, "utf", true); break; 
+					case "table": p = printTable(col.obj, cs-1, __, true, "utf"); break;
+					case "func" : p = String(newFn("mx", "my", col.obj)((aX * yspan)-1, cs-1)).split(/\r?\n/).map(r => r.substring(0, cs-1)).join("\n"); break;
+					default: p = String(col.obj).split(/\r?\n/).map(r => r.substring(0, cs-1)).join("\n");
 					}
 	
 					if (isDef(col.title)) {


### PR DESCRIPTION
- [ow.format.grid: correct mx and my](https://github.com/OpenAF/openaf/commit/62d78bcca0be4866519aa0d42927c27c473d52d2)