### PR TITLE
Enhance repack process with logging and timeout for temporary file check

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -16,10 +16,17 @@ jobs:
    - name  : Repack OpenAFOS
      deps  :
      - Build OpenAFOS
-     exec  : >
+     exec  : |
         log("Repacking...");
-        $sh(ow.format.getJavaHome() + "/bin/java -jar " + global.path + "/openaf.jar --repack")
-        .exec()
+        $sh(ow.format.getJavaHome() + "/bin/java -jar " + global.path + "/openaf.jar --repack").exec()
+
+        var isOk = false, init = now()
+        do {
+          sleep(1000, true)
+          if (!io.fileExists(global.path + "/openaf.jar.tmp")) isOk = true
+        } while (!isOk && now() - init < 60000)
+
+        log("Repacked.")
 
    # Copy OpenAF to the right place for use
    - name  : Copy OpenAF

--- a/src/openaf/OAFRepack.java
+++ b/src/openaf/OAFRepack.java
@@ -258,6 +258,7 @@ public class OAFRepack {
             if (zis != null) zis.close();
             if (fis != null) fis.close();
         }
+        System.out.println("Repack done.");
     }
 
     public static void repackAndReplace(String jarFile, String cmd) throws Exception {
@@ -268,7 +269,7 @@ public class OAFRepack {
         if (unix) {
             command.add("/bin/sh");
             command.add("-c");
-            command.add("sleep 1 && mv '" + jarFile + ".tmp' '" + jarFile + "' > /dev/null && " + cmd + ""); 
+            command.add("sleep 1 && echo Moving '" + jarFile + ".tmp' to '" + jarFile + "'... && mv '" + jarFile + ".tmp' '" + jarFile + "' && echo Moving done. && " + cmd + ""); 
         } else {
             command.add("cmd");
             command.add("/c");


### PR DESCRIPTION
This pull request includes changes to improve the repacking process for OpenAFOS and enhance logging for better debugging. The most important changes include modifications to the `build.yaml` configuration and updates to the `OAFRepack.java` file.

Improvements to repacking process:

* [`build.yaml`](diffhunk://#diff-2f7f69286606c0ff1642fac8ecb40ee91874b65bb544af172e32552c91a44799L19-R29): Enhanced the `exec` command in the `Repack OpenAFOS` job to include a loop that checks for the existence of a temporary file, ensuring the repacking process completes before proceeding.

Enhanced logging:

* [`src/openaf/OAFRepack.java`](diffhunk://#diff-fc00b59c319c6fcb9c0c87bb60229cc0b1757f2a41ed0d82ea016e1fa6879f8fR261): Added a log statement to indicate the completion of the repacking process in the `repack` method.
* [`src/openaf/OAFRepack.java`](diffhunk://#diff-fc00b59c319c6fcb9c0c87bb60229cc0b1757f2a41ed0d82ea016e1fa6879f8fL271-R272): Updated the `repackAndReplace` method to include additional log statements for better visibility of the file moving process.