### PR TITLE
opack: Refactor update function in opack.js to improve package update…

### DIFF
--- a/js/opack.js
+++ b/js/opack.js
@@ -1919,7 +1919,7 @@ function update(args) {
 		_packages.push(args[i])
 	}
 
-	var _stats = { updated: 0, failed: 0, notNeeded: 0 }
+	var _stats = { updated: 0, erasedToUpdate: 0, failed: 0, notNeeded: 0 }
 
 	// Update all packages
 	if (all) {
@@ -2022,12 +2022,12 @@ function update(args) {
 
 		if (ferase) {
 			var otherStats = erase([_pack], derase)
-			_stats.updated -= otherStats.erased
+			_stats.erasedToUpdate += otherStats.erased
 			_stats.failed += otherStats.failed
 		}
 		var otherStats = install([_pack])
 		if (isDef(otherStats)) {
-			_stats.updated += otherStats.installed * (ferase ? 2 : 1)
+			_stats.updated += otherStats.installed
 			_stats.failed += otherStats.failed
 			_stats.notNeeded += otherStats.notNeeded
 		}


### PR DESCRIPTION
This pull request includes changes to the `update` function in `js/opack.js` to improve the tracking of package updates and erasures.

Improvements to tracking statistics:

* [`js/opack.js`](diffhunk://#diff-22c5c8db79586efb03e491c117ac18d597f9d753896aed83338538ea46c1d4bdL1922-R1922): Added a new property `erasedToUpdate` to the `_stats` object to separately track the number of packages erased for updating.
* [`js/opack.js`](diffhunk://#diff-22c5c8db79586efb03e491c117ac18d597f9d753896aed83338538ea46c1d4bdL2025-R2030): Modified the logic to correctly increment the `erasedToUpdate` property instead of decrementing the `updated` property when packages are erased for updating.… statistics handling