### PR TITLE
Update Java source and target version to 21 in buildos.js

### DIFF
--- a/buildos.js
+++ b/buildos.js
@@ -150,7 +150,7 @@ io.writeFileString(OPENAF_BUILD_HOME + "/js/openaf.js", jsOpenAF);
 
 io.rm(OPENAF_BIN);
 io.mkdir(OPENAF_BIN);
-var cmd = JAVAC + " -cp " + classpath + " -encoding UTF-8 -source 1.8 -target 1.8 -Xlint:deprecation -d " + OPENAF_BIN + " " + buildSource();
+var cmd = JAVAC + " -cp " + classpath + " -encoding UTF-8 -source 21 -target 21 -Xlint:deprecation -d " + OPENAF_BIN + " " + buildSource();
 log("Compiling...");
 log(af.sh(cmd, "", undefined, true));
 if (__exitcode != 0) {


### PR DESCRIPTION
This pull request includes a small but important change to the `buildos.js` file. The change updates the Java source and target version used in the compilation process.

* [`buildos.js`](diffhunk://#diff-0d9b26017af779b7a26941397c3c2f123eaca2c3ace61aa95733fcd1f0f2fadfL153-R153): Updated the Java source and target version from 1.8 to 21 in the compilation command.