### PR TITLE
Add Launcher class and update build scripts for Java 21 compatibility

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -18,7 +18,7 @@ jobs:
      - Build OpenAFOS
      exec  : |
         log("Repacking...");
-        $sh(ow.format.getJavaHome() + "/bin/java -jar " + global.path + "/openaf.jar --repack").exec()
+        $sh().envs({ __OAF_MAINCLASS: "openaf.Launcher" }, true).sh([ow.format.getJavaHome() + "/bin/java", "-jar", global.path + "/openaf.jar", "--repack"]).exec()
 
         var isOk = false, init = now()
         do {

--- a/buildos.js
+++ b/buildos.js
@@ -156,6 +156,7 @@ log(af.sh(cmd, "", undefined, true));
 if (__exitcode != 0) {
 	logErr("Error compiling: " + __stderr);
 }
+$sh(JAVAC + " -source 8 -target 8 -d " + OPENAF_BIN + " " + OPENAF_SRC + "/openaf/Launcher.java").exec();
 
 var tempJar = new ZIP(io.readFileBytes(OPENAF_BUILD_HOME + "/jar-in-jar-loader.zip"));
 var binFiles = listFiles(OPENAF_BIN, new RegExp("\.class$"));
@@ -360,7 +361,8 @@ log("Adding manifest");
 var manifest = "Manifest-Version: 1.0\n";
 manifest += "Rsrc-Class-Path: ./" + smallClassPath + "\n";
 manifest += "Class-Path: .\n";
-manifest += "Rsrc-Main-Class: openaf._AFCmdOS\n";
+//manifest += "Rsrc-Main-Class: openaf._AFCmdOS\n";
+manifest += "Rsrc-Main-Class: openaf.Launcher\n";
 manifest += "Main-Class: org.eclipse.jdt.internal.jarinjarloader.JarRsrcLoader\n";
 tempJar.putFile("META-INF/MANIFEST.MF", af.fromString2Bytes(manifest));
 tempJar.putFile("META-INF/services/javax.script.ScriptEngineFactory", af.fromString2Bytes("openaf.OAFEngineFactory"));

--- a/js/repack.js
+++ b/js/repack.js
@@ -9,7 +9,7 @@ __logFormat.async = false
 
 var createTmp = false;
 
-//Check if a Jar was repacked
+//Check if a Jar was repacked and if main class is no longer openaf.Launcher
 function isRepackJar(aJarFilePath) {
 	var res = true;
 
@@ -87,6 +87,17 @@ var includeMore = {};
 var mainClass = undefined;
 
 var irj = isRepackJar(classPath);
+log("Checking OpenAF launcher...")
+if (irj && isUnDef(getEnv("__OAF_MAINCLASS"))) {
+	var _zip = new ZIP()
+	var str = af.fromBytes2String(_zip.streamGetFile(classPath, "META-INF/MANIFEST.MF"))
+	if (str.match(/Main-Class: openaf.Launcher/)) {
+		var _newClass = (isDef(mainClass)) ? mainClass : "openaf.AFCmdOS"
+		log("Replacing main class with " + _newClass + "...")
+		str = str.replace(/Main-Class: openaf.Launcher/g, "Main-Class: " + _newClass)
+		_zip.streamPutFile(classPath, "META-INF/MANIFEST.MF", af.fromString2Bytes(str))
+	}
+}
 
 try {
 // Set .package.json	

--- a/src/openaf/Launcher.java
+++ b/src/openaf/Launcher.java
@@ -1,0 +1,34 @@
+package openaf;
+
+/**
+ * 
+ * Copyright 2025 Nuno Aguiar
+ * 
+ */
+
+public class Launcher {
+    public static void main(String[] args) {
+        // Java version check
+		String version = System.getProperty("java.version");
+
+        // If lower than 21 print warning and end
+        if (isJavaVersionBelow21(version)) {
+            System.err.println("Warning: You are using java " + version + ". Please use or upgrade to Java >= 21.");
+            System.exit(1);
+        }
+
+        // Proceed with the normal execution
+        try {
+            Class<?> cls = Class.forName("openaf._AFCmdOS");
+            cls.getMethod("main", String[].class).invoke(null, (Object) args);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static boolean isJavaVersionBelow21(String version) {
+        String[] parts = version.split("\\.");
+        int major = Integer.parseInt(parts[0]);
+        return major < 21;
+    }
+}

--- a/src/openaf/OAFRepack.java
+++ b/src/openaf/OAFRepack.java
@@ -98,6 +98,16 @@ public class OAFRepack {
         
         ZipInputStream zis = null;
         FileInputStream fis = null;
+
+        // If environment variable __OAF_MAINCLASS exists then replace mainClass with it
+        // NOTE: this should only be used for original packing proposes with openaf.Launcer
+        String envMainClass = System.getenv("__OAF_MAINCLASS");
+        if (envMainClass != null) {
+            System.out.println("Previous main class: " + mainClass);
+            System.out.println("New main class: " + envMainClass);
+            mainClass = envMainClass;
+        }
+
         try {
             fis = new FileInputStream(aOrigFile);
             if (fis == null) throw new Exception("Couldn't read input file " + aOrigFile);

--- a/tests/oJobTypesTest.yaml
+++ b/tests/oJobTypesTest.yaml
@@ -42,7 +42,7 @@ jobs:
 - name: Via inline job
   args: |
     ({ verb: ow.oJob.init.hello })
-  exec: &EXE |
+  exec: &EXE | # javascript
     //yprint(args);
     if (isDef(args.verb) && args.verb == 'world') print("arg : yes"); else print("arg : NO!!!");
     if (isDef(args.init)) print("init: yes"); else print("init: NO!!!");

--- a/tests/testOJobShort.yaml
+++ b/tests/testOJobShort.yaml
@@ -4,7 +4,8 @@ jobs:
   from:
   # Running function getVersion
   - (fn): getVersion
-  exec: |
+  # Using YAML Embedded Language in VSCode
+  exec: | # javascript
     // Setting comparing values
     args.a = $get("res")
     args.b = getVersion()
@@ -55,6 +56,51 @@ jobs:
   # Cleanup
   - (unset     ): res
 
+# --------------------
+- name: Test SQL query
+  from:
+  - (pass   ):
+      data:
+      - id  : 1
+        name: Id 1
+      - id  : 2
+        name: Id 2
+  - (set    ): data
+    ((path )): data
+  - (query  ): | #sql
+      select count(1) as "count"
+    ((key  )): data
+    ((type )): sql
+    ((toKey)): res
+  to  :
+  - (pass      ):
+      a: "{{$path ($get 'res') '[0].count'}}"
+      b: "2"
+  - (testAssert): Problem with query
+
+# ---------------
+- name: Test oAFp
+  from:
+  - (pass   ):
+      data:
+      - id  : 1
+        name: Id 1
+      - id  : 2
+        name: Id 2
+  - (set    ): data
+    ((path )): data
+  - (oafp   ):
+      in    : key
+      data  : data
+      path  : "[0]"
+      out   : key
+      __key : res
+  to  :
+  - (pass      ):
+      a: "{{$path ($get 'res') 'id'}}"
+      b: "1"
+  - (testAssert): Problem with oAFp
+
 # ----------------------
 - name: Test todo simple
   from:
@@ -89,4 +135,6 @@ todo:
 - Test fn bi-directional
 - Test ch simple
 - Test todo simple
+- Test SQL query
+- Test oAFp
 - oJob Jobs Final Report 


### PR DESCRIPTION
This pull request includes several changes to the `build` and `test` processes, as well as updates to the `Launcher` class and other related files. The most important changes are grouped by theme below:

### Build Process Improvements:
* Updated the `build.yaml` to use environment variables for the main class during the repacking process, ensuring better flexibility and maintainability.
* Added a new command in `buildos.js` to compile the `Launcher` class with specific Java version targets.
* Modified the manifest file generation in `buildos.js` to use `openaf.Launcher` as the main class instead of `openaf._AFCmdOS`.

### Launcher Class Updates:
* Introduced a new `Launcher` class in `src/openaf/Launcher.java` to handle Java version checks and delegate execution to the existing main class.
* Updated `OAFRepack.java` to replace the main class with an environment variable if it exists, providing more flexibility during the repacking process.

### Test Enhancements:
* Added inline comments to indicate the use of JavaScript in `tests/oJobTypesTest.yaml` and `tests/testOJobShort.yaml`. [[1]](diffhunk://#diff-d86a32676598d159284563e714bbdbc8bf04ad8b8857be91638efcf71c5f556cL45-R45) [[2]](diffhunk://#diff-edd5fe1d5e6f940cf8ddb4481771be44a97125105a2fe739ba64247ea0aa4ad9L7-R8)
* Introduced new test cases for SQL queries and `oAFp` in `tests/testOJobShort.yaml`, enhancing the coverage and robustness of the test suite. [[1]](diffhunk://#diff-edd5fe1d5e6f940cf8ddb4481771be44a97125105a2fe739ba64247ea0aa4ad9R59-R103) [[2]](diffhunk://#diff-edd5fe1d5e6f940cf8ddb4481771be44a97125105a2fe739ba64247ea0aa4ad9R138-R139)

These changes collectively improve the build process, enhance the flexibility of the main class handling, and expand the test coverage to ensure better reliability and maintainability of the codebase.