### PR TITLE
T8

### DIFF
--- a/hbs/md.hbs
+++ b/hbs/md.hbs
@@ -51,7 +51,7 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', eve
 {{/if}}
 {{{markdown}}}
 {{#if themedark}}<script>document.querySelectorAll('pre code').forEach((block) => { block.classList.add('hljs_dark') })</script>{{/if}}
-{{#if themeauto}}<script>document.querySelectorAll('pre code').forEach((block) => { block.classList.add('hljs_dark') })</script>{{/if}}
+{{#if themeauto}}<script>if (__isDark) document.querySelectorAll('pre code').forEach((block) => { block.classList.add('hljs_dark') })</script>{{/if}}
 {{#if mdcodeclip}}<script src="/js/mdcodeclip.js"></script>{{/if}}
 </body>
 </html>


### PR DESCRIPTION
This pull request introduces several enhancements and bug fixes to improve the functionality and performance of the codebase. The key changes include improvements to the dark mode theme handling in the `hbs/md.hbs` file and the addition of new methods for managing Java Flight Recorder (JFR) in the `js/owrap.java.js` file.

### Improvements to dark mode theme handling:
* [`hbs/md.hbs`](diffhunk://#diff-d7840a0e45281e930db88ba7fd1010a3c55bb02b69a3902712cf2fe7f9183c57L54-R54): Updated the dark mode theme handling logic to check the `__isDark` variable before applying the `hljs_dark` class to code blocks when `themeauto` is enabled.

### Additions for Java Flight Recorder (JFR) management:
* [`js/owrap.java.js`](diffhunk://#diff-e224bdd5feac5fd5dca67af9a3a17737dc112baa91dd49591a525494b3c83b42R443-R645): Added the `pidStartJFR` method to start a Java Flight Recorder on a local JVM, ensuring compatibility with Java 14 or later.
* [`js/owrap.java.js`](diffhunk://#diff-e224bdd5feac5fd5dca67af9a3a17737dc112baa91dd49591a525494b3c83b42R443-R645): Added the `pidStopJFR` method to stop a Java Flight Recorder on a local JVM, ensuring compatibility with Java 14 or later.
* [`js/owrap.java.js`](diffhunk://#diff-e224bdd5feac5fd5dca67af9a3a17737dc112baa91dd49591a525494b3c83b42R443-R645): Added the `pidDumpJFR` method to dump a Java Flight Recorder on a local JVM, ensuring compatibility with Java 14 or later.
* [`js/owrap.java.js`](diffhunk://#diff-e224bdd5feac5fd5dca67af9a3a17737dc112baa91dd49591a525494b3c83b42R443-R645): Added the `parseJFR` method to parse a Java Flight Recorder file, providing detailed event data and ensuring compatibility with Java 14 or later.