### PR TITLE
document support for processing environment variables as arguments in ojob

### DIFF
--- a/docs/ojob-all.yaml
+++ b/docs/ojob-all.yaml
@@ -46,6 +46,7 @@ ojob:
     // Javascript OpenAF code to execute by default, with variables 'args', 'job' and 'id', if a job dependency failed it's execution
   depsTimeout: 300000  # If defined, represents the maximum elapsed time, in ms, from the first point in time a jobs[].deps was evaluated to determine if all deps had successfully executed
   templateArgs: true   # Boolean that if defined will process "{{ }}" handlebars entries on args using the "args" before the actual processing starts
+  argsFromEnvs: true   # Boolean that if true will process the environment variables as args (e.g. ARG0=1234 will be available as args.arg0)
 
   ## --- LOG CONTROL ---
 


### PR DESCRIPTION
This pull request includes a small change to the `docs/ojob-all.yaml` file. The change adds a new configuration option to process environment variables as arguments for jobs.

* [`docs/ojob-all.yaml`](diffhunk://#diff-2e454c60adfc2eed631de3b402f63ef701a9f01207720e4469882bee71ba8323R49): Added `argsFromEnvs` boolean option to process environment variables as job arguments.… ojob configuration