### PR TITLE
Fix tool execution for Ollama GPT wrapper

### DIFF
--- a/js/owrap.ai.js
+++ b/js/owrap.ai.js
@@ -191,7 +191,7 @@ OpenWrap.ai.prototype.__gpttypes = {
                     aModel       = _$(aModel, "aModel").isString().default(_model)
                     aJsonFlag    = _$(aJsonFlag, "aJsonFlag").isBoolean().default(false)
                     aTools       = _$(aTools, "aTools").isArray().default(_r.tools)
-                 
+
                     var msgs = []
                     if (isString(aPrompt)) aPrompt = [ aPrompt ]
                     aPrompt = _r.conversation.concat(aPrompt)
@@ -478,7 +478,7 @@ OpenWrap.ai.prototype.__gpttypes = {
                     aModel       = _$(aModel, "aModel").isString().default(_model)
                     aJsonFlag    = _$(aJsonFlag, "aJsonFlag").isBoolean().default(false)
                     aTools       = _$(aTools, "aTools").isArray().default(_r.tools)
-                 
+
                     var msgs = []
                     if (isString(aPrompt)) aPrompt = [ { role: "user", parts: [ { text: aPrompt } ] } ]
                     aPrompt = _r.conversation.reduce((acc, r) => {
@@ -721,7 +721,7 @@ OpenWrap.ai.prototype.__gpttypes = {
                     aTemperature = _$(aTemperature, "aTemperature").isNumber().default(_temperature)
                     aModel       = _$(aModel, "aModel").isString().default(_model)
                     aJsonFlag    = _$(aJsonFlag, "aJsonFlag").isBoolean().default(false)
-                    aTools       = _$(aTools, "aTools").isArray().default(_r.tools)
+                    aTools       = _$(aTools, "aTools").isArray().default(Object.keys(_r.tools))
                  
                     var msgs = []
                     if (isString(aPrompt)) aPrompt = [ aPrompt ]
@@ -762,8 +762,9 @@ OpenWrap.ai.prototype.__gpttypes = {
                         _res.message["tool_calls"].forEach(tc => {
                             if (isDef(tc.function)) {
                                 var _t = _r.tools[tc.function.name]
-                                var _tr = stringify(_t.fn(_t.arguments), __, "")
-                                if (isDef(tc.function.id)) _tr.tool_call_id = tc.function.id
+                                var _args = jsonParse(tc.function.arguments)
+                                var _tr = stringify(_t.fn(_args), __, "")
+                                _p.push({ role: "assistant", tool_calls: [ tc ] })
                                 _p.push({ role: "tool", content: _tr, tool_call_id: tc.function.id })
                             }
                         })


### PR DESCRIPTION
## Summary
- ensure Ollama GPT wrapper passes registered tool definitions when none are specified
- correctly invoke tool functions and forward their results back to the model

## Testing
- `ojob autoTestAll.yaml` *(fails: No entry for 'oJob-common' on remote OPack database(s))*
