### PR TITLE
Add stats reporting to GPT wrappers

### DIFF
--- a/js/openaf.js
+++ b/js/openaf.js
@@ -10417,9 +10417,19 @@ AF.prototype.fromSQL2NLinq = function(sql, preParse) {
  * </odoc>
  */
 const $llm = function(aModel) {
-	if (global.$gpt) return $gpt(aModel)
-	ow.loadAI()
-	return $gpt(aModel)
+        if (global.$gpt) return $gpt(aModel)
+        ow.loadAI()
+        return $gpt(aModel)
+}
+
+/**
+ * <odoc>
+ * <key>$LLM(aModel) : $gpt</key>
+ * Alias for $llm to keep backwards compatibility with upper-case invocations.
+ * </odoc>
+ */
+const $LLM = function(aModel) {
+        return $llm(aModel)
 }
 
 /**


### PR DESCRIPTION
## Summary
- capture vendor-provided usage/token statistics in each ow.ai GPT implementation and expose them via getLastStats
- add promptWithStats/rawPromptWithStats helpers to ow.ai.gpt and $gpt for easy access to responses and stats, and provide an uppercase $LLM alias

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d459b883c48332a28389d17508ba84