### PR TITLE
Upgrade OkHttp to 5.2.0

### DIFF
--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -3009,10 +3009,10 @@ APPENDIX: How to apply the Apache License to your work
 
 -----------------------
 Third-party name      : OkHTTP Client
-Version               : 4.12.0
+Version               : 5.2.0
 Changed from original : No
-Location in openaf.jar: okhttp-4.12.0.jar, okio-3.9.1.jar, okio-jvm-3.9.1.jar, kotlin-stdlib-2.0.20.jar
-License               : 
+Location in openaf.jar: okhttp-5.2.0.jar, okhttp-jvm-5.2.0.jar, okio-3.16.0.jar, okio-jvm-3.16.0.jar, kotlin-stdlib-2.2.20.jar
+License               :
 
 
 

--- a/js/owrap.obj.js
+++ b/js/owrap.obj.js
@@ -1941,28 +1941,28 @@ OpenWrap.obj.prototype.http.prototype.exec = function(aURL, aRequestType, aIn, a
 	if (__flags.HTTP_USE_MEDIA_TYPE) if (isDef(aRequestMap["Content-Type"])) mediaType = aRequestMap["Content-Type"]
 
 	if (isDef(aIn)) {
-		if (isBytes) {
-			aBody = Packages.okhttp3.RequestBody.create(isNull(mediaType) ? null : Packages.okhttp3.MediaType.get(mediaType), aIn)
-		} else {
-			aBody = Packages.okhttp3.RequestBody.create(isNull(mediaType) ? null : Packages.okhttp3.MediaType.get(mediaType), String(aIn))
-		}
-	} else {
-		if (isDef(this.__uf)) {
+                if (isBytes) {
+                        aBody = Packages.okhttp3.RequestBody.create(aIn, isNull(mediaType) ? null : Packages.okhttp3.MediaType.get(mediaType))
+                } else {
+                        aBody = Packages.okhttp3.RequestBody.create(String(aIn), isNull(mediaType) ? null : Packages.okhttp3.MediaType.get(mediaType))
+                }
+        } else {
+                if (isDef(this.__uf)) {
 			var f 
 			if (isString(this.__uf)) {
 				f = new java.io.File(this.__uf)
 			} else {
 				f = this.__uf
 			}
-			if (isUnDef(this.__ufn)) {
-				aBody = Packages.okhttp3.RequestBody.create(isNull(mediaType) ? null : Packages.okhttp3.MediaType.get(mediaType), f)
-			} else {
-				aBody = Packages.okhttp3.MultipartBody.Builder().setType(Packages.okhttp3.MultipartBody.FORM).addFormDataPart(this.__ufn, this.__uf, Packages.okhttp3.RequestBody.create(isNull(mediaType) ? Packages.okhttp3.MediaType.get("application/octet-stream") : Packages.okhttp3.MediaType.get(mediaType), f)).build()
-			}
-		} else {
-			aBody = Packages.okhttp3.RequestBody.create(Packages.okhttp3.MediaType.get("application/json"), "")
-		}
-	}
+                        if (isUnDef(this.__ufn)) {
+                                aBody = Packages.okhttp3.RequestBody.create(f, isNull(mediaType) ? null : Packages.okhttp3.MediaType.get(mediaType))
+                        } else {
+                                aBody = Packages.okhttp3.MultipartBody.Builder().setType(Packages.okhttp3.MultipartBody.FORM).addFormDataPart(this.__ufn, this.__uf, Packages.okhttp3.RequestBody.create(f, isNull(mediaType) ? Packages.okhttp3.MediaType.get("application/octet-stream") : Packages.okhttp3.MediaType.get(mediaType))).build()
+                        }
+                } else {
+                        aBody = Packages.okhttp3.RequestBody.create("", Packages.okhttp3.MediaType.get("application/json"))
+                }
+        }
 
 	if (isUnDef(aRequestType)) aRequestType = "GET";
 

--- a/pom.xml
+++ b/pom.xml
@@ -320,12 +320,17 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>4.12.0</version>
-    </dependency>    
+      <version>5.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp-jvm</artifactId>
+      <version>5.2.0</version>
+    </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>2.2.0</version>
+      <version>2.2.20</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okio</groupId>

--- a/versionsAndDeps.json
+++ b/versionsAndDeps.json
@@ -231,10 +231,10 @@
 			"license": "https://raw.githubusercontent.com/licenses/license-templates/master/templates/apache.txt",
 			"deps": []
 		},
-	   {
-		   "description": "OkHTTP Client",
-		   "path": ["okhttp-4.12.0.jar", "okio-3.15.0.jar", "okio-jvm-3.15.0.jar", "kotlin-stdlib-2.2.0.jar"],
-		   "version": "4.12.0",
+          {
+                  "description": "OkHTTP Client",
+                  "path": ["okhttp-5.2.0.jar", "okhttp-jvm-5.2.0.jar", "okio-3.16.0.jar", "okio-jvm-3.16.0.jar", "kotlin-stdlib-2.2.20.jar"],
+                  "version": "5.2.0",
 			"changes": false,
 			"type": ["java"],
 			"license": "https://github.com/square/okhttp/blob/master/LICENSE.txt",


### PR DESCRIPTION
## Summary
- bump the OkHttp dependencies to 5.2.0 and align the Kotlin stdlib version
- update the HTTP wrapper to use the content-first RequestBody.create overloads
- refresh dependency metadata to reflect the upgraded OkHttp distribution

## Testing
- not run (not requested)
