### PR TITLE
Codex/add error handling and new functions in gpt

### DIFF
--- a/js/owrap.ai.js
+++ b/js/owrap.ai.js
@@ -148,6 +148,7 @@ OpenWrap.ai.prototype.__gpttypes = {
             var _r = {
                 conversation: [],
                 tools: {},
+                getModelName: () => _model,
                 getConversation: () => {
                     return _r.conversation
                 },
@@ -476,10 +477,11 @@ OpenWrap.ai.prototype.__gpttypes = {
             var _r = {
                 conversation: [],
                 tools: [],
+                getModelName: () => _model,
                 getConversation: () => {
                     var _res = _r.conversation.map(r => {
                         if (isMap(r)) {
-                            if (isUnDef(r.role)) 
+                            if (isUnDef(r.role))
                                 r.role = "user"
                             else if (r.role == "assistant") {
                                 r.role = "model"
@@ -853,6 +855,7 @@ OpenWrap.ai.prototype.__gpttypes = {
             var _r = {
                 conversation: [],
                 tools: [],
+                getModelName: () => _model,
                 getConversation: () => {
                     return _r.conversation
                 },
@@ -1150,6 +1153,7 @@ OpenWrap.ai.prototype.__gpttypes = {
             var _r = {
                 conversation: [],
                 tools: {},
+                getModelName: () => _model,
                 getConversation: () => {
                     return _r.conversation
                 },
@@ -1411,11 +1415,53 @@ OpenWrap.ai.prototype.__gpttypes = {
  * </odoc>
  */
 OpenWrap.ai.prototype.gpt = function(aType, aOptions) {
-    if (isUnDef(ow.ai.__gpttypes[aType])) {
-        throw "Unrecognized GPT type '" + aType + "'."
-    } else {
-        this.model = ow.ai.__gpttypes[aType].create(aOptions)
+    if (!isString(aType) || aType.trim().length == 0) {
+        throw new Error("GPT type must be a non-empty string.")
     }
+
+    var _type = aType.trim()
+    var _types = isMap(ow.ai.__gpttypes) ? Object.keys(ow.ai.__gpttypes) : []
+    var _impl = isMap(ow.ai.__gpttypes) ? ow.ai.__gpttypes[_type] : __
+
+    if (isUnDef(_impl)) {
+        var _msg = "Unrecognized GPT type '" + _type + "'."
+        if (_types.length > 0) {
+            _msg += " Available types: " + _types.join(", ")
+        }
+        throw new Error(_msg)
+    }
+
+    this.__type = _type
+    this.model = _impl.create(aOptions)
+    var _modelName = (isDef(this.model) && isFunction(this.model.getModelName)) ? this.model.getModelName() : __
+    if (isUnDef(_modelName) && isMap(aOptions) && isString(aOptions.model)) {
+        _modelName = aOptions.model
+    }
+    this.__modelName = _modelName
+}
+
+/**
+ * <odoc>
+ * <key>ow.ai.gpt.prototype.getType() : String</key>
+ * Returns the GPT provider type used to create this instance.
+ * </odoc>
+ */
+OpenWrap.ai.prototype.gpt.prototype.getType = function() {
+    return this.__type
+}
+
+/**
+ * <odoc>
+ * <key>ow.ai.gpt.prototype.getModelName() : String</key>
+ * Returns the default model name configured for this GPT instance.
+ * </odoc>
+ */
+OpenWrap.ai.prototype.gpt.prototype.getModelName = function() {
+    if (isDef(this.model) && isFunction(this.model.getModelName)) {
+        var _name = this.model.getModelName()
+        if (isDef(_name)) this.__modelName = _name
+    }
+    return this.__modelName
 }
 
 /**


### PR DESCRIPTION
This pull request enhances the `OpenWrap.ai` GPT integration by improving type validation, error messages, and model metadata access. The main changes add methods for retrieving the GPT type and model name, and make error handling more robust when initializing GPT instances.

**Improvements to GPT instance creation and metadata:**

* Improved validation and error reporting in `OpenWrap.ai.prototype.gpt`:
  * Now checks that the GPT type is a non-empty string and provides a clearer error message listing available types if an unrecognized type is provided.
* Added `getType` and `getModelName` methods to `OpenWrap.ai.prototype.gpt.prototype` to allow retrieval of the GPT provider type and configured model name for each instance.

**Enhancements to internal GPT type objects:**

* Added a `getModelName` method to each GPT type implementation in `__gpttypes`, allowing consistent access to the model name used by each GPT type. [[1]](diffhunk://#diff-184d2cbefa7d7f91b25bf24fe2d80ee95cbe8ed9824a9c6582bfb72d4221d165R151) [[2]](diffhunk://#diff-184d2cbefa7d7f91b25bf24fe2d80ee95cbe8ed9824a9c6582bfb72d4221d165R480) [[3]](diffhunk://#diff-184d2cbefa7d7f91b25bf24fe2d80ee95cbe8ed9824a9c6582bfb72d4221d165R858) [[4]](diffhunk://#diff-184d2cbefa7d7f91b25bf24fe2d80ee95cbe8ed9824a9c6582bfb72d4221d165R1156)