### PR TITLE
fix(ai): normalize raw prompt response for consistent JSON parsing

### DIFF
--- a/js/owrap.ai.js
+++ b/js/owrap.ai.js
@@ -3506,8 +3506,16 @@ OpenWrap.ai.prototype.gpt.prototype.jsonPromptWithStats = function(aPrompt, aMod
 OpenWrap.ai.prototype.gpt.prototype.jsonPromptWithStatsRaw = function(aPrompt, aModel, aTemperature, tools) {
     this.setInstructions("json")
 
-    var out = this.model.prompt(aPrompt, aModel, aTemperature, true, tools)
-    var parsed = isString(out) ? jsonParse(out, __, __, true) : out
+    var out = this.model.rawPrompt(aPrompt, aModel, aTemperature, true, tools)
+    var normalized = out
+    if (isMap(out)) {
+        if (isMap(out.message) && isString(out.message.content)) {
+            normalized = out.message.content
+        } else if (isString(out.response)) {
+            normalized = out.response
+        }
+    }
+    var parsed = isString(normalized) ? jsonParse(normalized, __, __, true) : normalized
     return { response: parsed, raw: out, stats: this.getLastStats() }
 }
 


### PR DESCRIPTION
This pull request refactors the `jsonPromptWithStatsRaw` method in `js/owrap.ai.js` to improve how the raw model output is normalized and parsed. The main change is to handle different possible response formats from the model, ensuring that the correct content is extracted and parsed as JSON.

**Improvements to model output handling:**

* Updated `jsonPromptWithStatsRaw` to use `rawPrompt` instead of `prompt`, and added logic to normalize the model output by extracting the relevant content from nested objects before attempting JSON parsing. This improves robustness when handling different response formats from the model.